### PR TITLE
Display license icon on watch page

### DIFF
--- a/client/video-watch-client-plugin.js
+++ b/client/video-watch-client-plugin.js
@@ -59,19 +59,20 @@ function register ({ registerHook, peertubeHelpers }) {
     handler: ( videojs, video ) => {
       // Insert licence icon next to date and views info elements
       {
-        let licenceHref    = CCLicenceInfo[videoLicence.label].href;
-        let licenceIconSrc = CCLicenceInfo[videoLicence.label].iconSrc;
+        if (videoLicence && Object.keys(CCLicenceInfo).includes(videoLicence.label)) {
+          let licenceHref    = CCLicenceInfo[videoLicence.label].href;
+          let licenceIconSrc = CCLicenceInfo[videoLicence.label].iconSrc;
 
-        let infoElems = document.getElementsByClassName('video-info-date-views')
-        
-        Array.from(infoElems).map(e => e.insertAdjacentHTML(
-          'beforeend', 
-          ` • 
-          <a rel="license" href="${licenceHref}" target="_blank">
-            <img src="${licenceIconSrc}" />
-          </a>`
-        ));
-
+          let infoElems = document.getElementsByClassName('video-info-date-views')
+          
+          Array.from(infoElems).map(e => e.insertAdjacentHTML(
+            'beforeend', 
+            ` • 
+            <a rel="license" href="${licenceHref}" target="_blank">
+              <img src="${licenceIconSrc}" />
+            </a>`
+          ));
+        }
       }
     }
   })  

--- a/client/video-watch-client-plugin.js
+++ b/client/video-watch-client-plugin.js
@@ -1,0 +1,90 @@
+function register ({ registerHook, peertubeHelpers }) {
+  // TODO declare licence info in external place
+  // TODO DRY use across client and server?
+  const CCLicenceInfo = {
+    "CC-BY": {
+      id: 1,
+      iconSrc: "https://licensebuttons.net/l/by/4.0/80x15.png",
+      href: "https://creativecommons.org/licenses/by/4.0/" 
+    },
+    "CC-BY-SA": {
+      id: 2,
+      iconSrc: "https://licensebuttons.net/l/by-sa/4.0/80x15.png",
+      href: "https://creativecommons.org/licenses/by-sa/4.0/" 
+    },
+    "CC-BY-ND": {
+      id: 3,
+      iconSrc: "https://licensebuttons.net/l/by-nd/4.0/80x15.png",
+      href: "https://creativecommons.org/licenses/by-nd/4.0/" 
+    },
+    "CC-BY-NC": {
+      id: 4,
+      iconSrc: "https://licensebuttons.net/l/by-nc/4.0/80x15.png",
+      href: "https://creativecommons.org/licenses/by-nc/4.0/" 
+    },
+    "CC-BY-NC-SA": {
+      id: 5,
+      iconSrc: "https://licensebuttons.net/l/by-nc-sa/4.0/80x15.png",
+      href: "https://creativecommons.org/licenses/by-nc-sa/4.0/" 
+    },
+    "CC-BY-NC-ND": {
+      id: 6,
+      iconSrc: "https://licensebuttons.net/l/by-nc-nd/4.0/80x15.png",
+      href: "https://creativecommons.org/licenses/by-nc-nd/4.0/" 
+    },
+    "CC0": {
+      id: 7,
+      iconSrc: "https://licensebuttons.net/l/zero/1.0/80x15.png",
+      href: "https://creativecommons.org/share-your-work/public-domain/cc0" 
+    },
+    "PDM": {
+      id: 8,
+      iconSrc: "https://licensebuttons.net/l/publicdomain/80x15.png",
+      href: "https://creativecommons.org/share-your-work/public-domain/pdm" 
+    }
+  };
+
+  let videoLicence;
+
+  registerHook({
+    target: 'filter:api.video-watch.video.get.result',
+    handler: video => {
+      videoLicence = video.licence
+      return video
+    }
+  })
+
+  registerHook({
+    target: 'action:video-watch.video.loaded',
+    handler: ( videojs, video ) => {
+      // Insert licence icon next to date and views info elements
+      {
+        let licenceHref    = CCLicenceInfo[videoLicence.label].href;
+        let licenceIconSrc = CCLicenceInfo[videoLicence.label].iconSrc;
+
+        let infoElems = document.getElementsByClassName('video-info-date-views')
+        
+        Array.from(infoElems).map(e => e.insertAdjacentHTML(
+          'beforeend', 
+          ` • 
+          <a rel="license" href="${licenceHref}" target="_blank">
+            <img src="${licenceIconSrc}" />
+          </a>`
+        ));
+
+      }
+    }
+  })  
+
+  // Why does infoElems in video-watch.video.loaded handler remain empty without this hook? 
+  registerHook({
+    target: 'filter:internal.video-watch.player.build-options.result',
+    handler: (result, params) => {
+      return result
+    }
+  })
+}
+
+export {
+  register
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,14 @@
   },
   "license" : "AGPL-3.0",
   "bugs": "https://github.com/beeldengeluid/peertube-plugin-creative-commons/issues",
-  "clientScripts": [],
+  "clientScripts": [
+    {
+      "script": "client/video-watch-client-plugin.js",
+      "scopes": [
+        "video-watch"
+      ]
+    }
+  ],
   "css": [],
   "devDependencies": {
     "@purtuga/esm-webpack-plugin": "^1.1.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,8 @@ const path = require("path")
 const EsmWebpackPlugin = require("@purtuga/esm-webpack-plugin")
 
 const clientFiles = [
-  'common-client-plugin.js'
+  'common-client-plugin.js',
+  'video-watch-client-plugin.js'
 ]
 
 let config = clientFiles.map(f => ({


### PR DESCRIPTION
Insert HTML snippet of relevant CC licence icon, linking its licence deed on watch page, underneath video on both narrow and wide screens.

closes #2 

@frankstrater I've marked two TODOs and a question in `/client/video-watch-client-plugin.js`, would be nice to get your thoughts.

I'd prefer to take care of those TODOs separately and merge this PR if you agree requirements of #2 are met.