### PR TITLE
Include licence metadata on watch page

### DIFF
--- a/client/video-watch-client-plugin.js
+++ b/client/video-watch-client-plugin.js
@@ -63,21 +63,45 @@ function register ({ registerHook, peertubeHelpers }) {
           let licenceHref    = CCLicenceInfo[videoLicence.label].href;
           let licenceIconSrc = CCLicenceInfo[videoLicence.label].iconSrc;
 
-          let infoElems = document.getElementsByClassName('video-info-date-views')
+          let videoInfoDateViewsElems = document.getElementsByClassName('video-info-date-views')
           
-          Array.from(infoElems).map(e => e.insertAdjacentHTML(
+          Array.from(videoInfoDateViewsElems).map(e => e.insertAdjacentHTML(
             'beforeend', 
             ` • 
             <a rel="license" href="${licenceHref}" target="_blank">
               <img src="${licenceIconSrc}" />
             </a>`
           ));
+
+          // Set Title metadata
+          let videoInfoNameElems = document.getElementsByClassName('video-info-name')
+          Array.from(videoInfoNameElems).map(e => {
+            e.setAttribute('xmlns:dct', 'http://purl.org/dc/terms/')
+            e.setAttribute('property', 'dct:title')
+          })
+
+          // Set Author metadata
+          let accountPageLinkElem = document.querySelector('[title="Account page"]');
+          accountPageLinkElem.setAttribute('xmlns:cc', 'https://creativecommons.org/ns#')
+          accountPageLinkElem.setAttribute('property', 'cc:attributionName')
+
+          // Set Work URL metadata
+          let canonicalLinkElem = document.querySelector('[rel="canonical"]');
+          canonicalLinkElem.insertAdjacentHTML(
+            'afterend', 
+            `<link 
+              xmlns:cc="https://creativecommons.org/ns#"
+              href="${canonicalLinkElem.getAttribute('href')}"
+              property="cc:attributionName"
+              rel="cc:attributionURL"
+            >`
+          );
         }
       }
     }
   })  
 
-  // Why does infoElems in video-watch.video.loaded handler remain empty without this hook? 
+  // Why does videoInfoDateViewsElems in video-watch.video.loaded handler remain empty without this hook? 
   registerHook({
     target: 'filter:internal.video-watch.player.build-options.result',
     handler: (result, params) => {

--- a/client/video-watch-client-plugin.js
+++ b/client/video-watch-client-plugin.js
@@ -81,7 +81,7 @@ function register ({ registerHook, peertubeHelpers }) {
           })
 
           // Set Author metadata
-          let accountPageLinkElem = document.querySelector('[title="Account page X"]');
+          let accountPageLinkElem = document.querySelector('[title="Account page"]');
           if (accountPageLinkElem) {
             accountPageLinkElem.setAttribute('xmlns:cc', 'https://creativecommons.org/ns#')
             accountPageLinkElem.setAttribute('property', 'cc:attributionName')

--- a/client/video-watch-client-plugin.js
+++ b/client/video-watch-client-plugin.js
@@ -81,9 +81,11 @@ function register ({ registerHook, peertubeHelpers }) {
           })
 
           // Set Author metadata
-          let accountPageLinkElem = document.querySelector('[title="Account page"]');
-          accountPageLinkElem.setAttribute('xmlns:cc', 'https://creativecommons.org/ns#')
-          accountPageLinkElem.setAttribute('property', 'cc:attributionName')
+          let accountPageLinkElem = document.querySelector('[title="Account page X"]');
+          if (accountPageLinkElem) {
+            accountPageLinkElem.setAttribute('xmlns:cc', 'https://creativecommons.org/ns#')
+            accountPageLinkElem.setAttribute('property', 'cc:attributionName')
+          }
 
           // Set Work URL metadata
           let canonicalLinkElem = document.querySelector('[rel="canonical"]');


### PR DESCRIPTION
include licence metadata on watch page by 
- inserting attributes to existing elements for Title and Author
- inserting new `link` tag for Work URL. 

closes #3 

@frankstrater I couldn't find a more robust way to find the Video Author element than querying for `'[title="Account page"]'`, which doesn't feel very future proof. Any ideas for less brittle ways to approach this?